### PR TITLE
Mac compatibility change Let to Var

### DIFF
--- a/components/HistoryTable.qml
+++ b/components/HistoryTable.qml
@@ -163,7 +163,7 @@ ListView {
                 font.family: LokiComponents.Style.fontLight.name
                 font.pixelSize: 14 * scaleRatio
                 text: {
-                  let base = isOut ? qsTr("Sent") : qsTr("Received");
+                  var base = isOut ? qsTr("Sent") : qsTr("Received");
 
                   if (isServiceNodeReward) {
                       base += qsTr(" (service node reward)");

--- a/main.qml
+++ b/main.qml
@@ -663,7 +663,7 @@ ApplicationWindow {
 
     function makeStakeConfirmationPopup(tx, address) {
 
-        let popup = transactionConfirmationPopup;
+        var popup = transactionConfirmationPopup;
 
         popup.title = qsTr("Please Confirm Staking Transaction:\n") + translationManager.emptyString;
         popup.icon = StandardIcon.Question

--- a/pages/ServiceNode.qml
+++ b/pages/ServiceNode.qml
@@ -133,9 +133,9 @@ Rectangle {
                       return false;
                   }
 
-                  let address_ok = walletManager.addressValid(getRewardAddress.text, appWindow.persistentSettings.nettype);
+                  var address_ok = walletManager.addressValid(getRewardAddress.text, appWindow.persistentSettings.nettype);
 
-                  let sn_pub_key = walletManager.serviceNodePubkeyValid(getServiceNodeKey.text);
+                  var sn_pub_key = walletManager.serviceNodePubkeyValid(getServiceNodeKey.text);
 
                   if (!address_ok || !sn_pub_key) return false;
 


### PR DESCRIPTION
This improves backwards compatibility where otherwise some of the older but still supported Qt QML compiler doesn't support the `let` keyword yet.