### PR TITLE
Improve build script reliability

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -104,8 +104,10 @@ elif [ "$platform" == "mingw64" ] || [ "$platform" == "mingw32" ]; then
 fi
 
 # force version update
+git fetch --tags --force
 get_tag
 echo "var GUI_VERSION = \"$TAGNAME\"" > version.js
+
 pushd "$LOKI_DIR"
 get_tag
 popd

--- a/get_libwallet_api.sh
+++ b/get_libwallet_api.sh
@@ -13,20 +13,13 @@ INSTALL_DIR=$ROOT_DIR/wallet
 LOKI_DIR=$ROOT_DIR/loki
 BUILD_LIBWALLET=false
 
-# init and update loki submodule
-git submodule init loki
-git submodule update --remote
+git submodule update --init --remote
 git -C $LOKI_DIR checkout master
+git -C $LOKI_DIR submodule update --init
 
 # get loki core tag
 git fetch --tags --force
 get_tag
-
-# create local loki branch, delete old release branch if it exists so we don't build a cached version
-git -C $LOKI_DIR branch -D release
-git -C $LOKI_DIR checkout -B $VERSIONTAG
-git -C $LOKI_DIR submodule init
-git -C $LOKI_DIR submodule update --recursive
 
 # Build libwallet if it doesnt exist
 if [ ! -f $LOKI_DIR/lib/libwallet_merged.a ]; then 

--- a/get_libwallet_api.sh
+++ b/get_libwallet_api.sh
@@ -14,20 +14,19 @@ LOKI_DIR=$ROOT_DIR/loki
 BUILD_LIBWALLET=false
 
 # init and update loki submodule
-if [ ! -d $LOKI_DIR/src ]; then
-    git submodule init loki
-fi
+git submodule init loki
 git submodule update --remote
-# git -C $LOKI_DIR fetch
 git -C $LOKI_DIR checkout master
 
 # get loki core tag
+git fetch --tags --force
 get_tag
-# create local loki branch
-git -C $LOKI_DIR checkout -B $VERSIONTAG
 
+# create local loki branch, delete old release branch if it exists so we don't build a cached version
+git -C $LOKI_DIR branch -D release
+git -C $LOKI_DIR checkout -B $VERSIONTAG
 git -C $LOKI_DIR submodule init
-git -C $LOKI_DIR submodule update
+git -C $LOKI_DIR submodule update --recursive
 
 # Build libwallet if it doesnt exist
 if [ ! -f $LOKI_DIR/lib/libwallet_merged.a ]; then 


### PR DESCRIPTION
Since PR merge has been removed, there's no need to create a temporary local branch which had the PR changes merged in- this also avoids the caching of this branch causing the build script to build with old changes unexpectedly.

Add a tag fetch so that the version tag built into the executable is always up to date.