### PR TITLE
always rebuild libwallet in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,8 @@ build:mac:
   script:
     - echo "QMAKE_LFLAGS += -mmacosx-version-min=10.10 -isysroot /Developer/SDKs/MacOSX10.10.sdk" >> loki-wallet-gui.pro
     - export MACOSX_DEPLOYMENT_TARGET=10.10
+    - rm -f loki/lib/libwallet_merged.a
+    - rm -rf build
     - ./build.sh release-static
     - cp loki/bin/lokid build/release/bin
   artifacts:

--- a/get_libwallet_api.sh
+++ b/get_libwallet_api.sh
@@ -14,7 +14,6 @@ LOKI_DIR=$ROOT_DIR/loki
 BUILD_LIBWALLET=false
 
 git submodule update --init --remote
-git -C $LOKI_DIR checkout master
 git -C $LOKI_DIR submodule update --init
 
 # get loki core tag


### PR DESCRIPTION
I believe `git submodule update --init --remote` already updates the submodule to the latest commit on master, which could be potentially undone with `git -C $LOKI_DIR checkout master` which updates to the local branch, correct?